### PR TITLE
add 'format' event

### DIFF
--- a/autocomplete/jquery.ui.autocomplete.html.js
+++ b/autocomplete/jquery.ui.autocomplete.html.js
@@ -30,9 +30,12 @@ $.extend( proto, {
 	},
 
 	_renderItem: function( ul, item) {
+		item.text = item.label;
+		this._trigger( 'format', null, item );
+
 		return $( "<li></li>" )
 			.data( "item.autocomplete", item )
-			.append( $( "<a></a>" )[ this.options.html ? "html" : "text" ]( item.label ) )
+			.append( $( "<a></a>" )[ this.options.html ? "html" : "text" ]( item.text ) )
 			.appendTo( ul );
 	}
 });


### PR DESCRIPTION
If the 'format' event is present, it is expected to set item.text to the actual text which should be rendered. Whether it is rendered as text or html will still depend on the 'html' option.

This is useful when you want to apply per-item formatting to the displayed results. In my case I wanted a different icon for various "types" of data which could be returned from the remote data source. Because the event has access to the data item, it can also access extra data which might be set (in addition to the "label" and "value" attributes).
