### PR TITLE
Compatible with autocomplete source function

### DIFF
--- a/src/autocomplete/jquery.ui.autocomplete.accentFolding.js
+++ b/src/autocomplete/jquery.ui.autocomplete.accentFolding.js
@@ -738,15 +738,13 @@ autocomplete.accentFolding = {
 	}
 };
 
-	$.ui.autocomplete.filter = function (array, term) {
-			var matcher = new RegExp( $.ui.autocomplete.escapeRegex(term), "i");
-			return $.grep(array, function (value) {
-				value = value.label || value.value || value;
-				return matcher.test( value ) ||
-				matcher.test( $.ui.autocomplete.accentFolding.fold( value ) );
-			});
-		};		
+$.ui.autocomplete.filter = function (array, term) {
+	var matcher = new RegExp( $.ui.autocomplete.escapeRegex(term), "i");
+	return $.grep(array, function (value) {
+		  value = value.label || value.value || value;
+		  return matcher.test( value ) ||
+			  matcher.test( $.ui.autocomplete.accentFolding.fold( value ) );
+		});
+};		
 
 })( jQuery );
-
-		

--- a/src/autocomplete/jquery.ui.autocomplete.accentFolding.js
+++ b/src/autocomplete/jquery.ui.autocomplete.accentFolding.js
@@ -738,21 +738,15 @@ autocomplete.accentFolding = {
 	}
 };
 
-var _initSource = autocomplete.prototype._initSource;
-autocomplete.prototype._initSource = function() {
-	var source = this.options.source;
-	if ( $.isArray(source) ) {
-		this.source = function( request, response ) {
-			var matcher = new RegExp( autocomplete.escapeRegex( request.term ), "i" );
-			response( $.grep( source, function( value ) {
+	$.ui.autocomplete.filter = function (array, term) {
+			var matcher = new RegExp( $.ui.autocomplete.escapeRegex(term), "i");
+			return $.grep(array, function (value) {
 				value = value.label || value.value || value;
 				return matcher.test( value ) ||
-					matcher.test( autocomplete.accentFolding.fold( value ) );
-			}) );
-		};
-	} else {
-		return _initSource.call( this );
-	}
-};
+				matcher.test( $.ui.autocomplete.accentFolding.fold( value ) );
+			});
+		};		
 
 })( jQuery );
+
+		


### PR DESCRIPTION
Call accentFolding.fold at $.ui.autocomplete.filter() and leaving autocomplete.source as original.
Works with the three types of source: array of values, function or url-string.
Tested with "multiple" jquery-ui autocomplete example. https://jqueryui.com/autocomplete/#multiple
