### PR TITLE
accentFolding: this code is useful enough to be used without jQuery UI

### DIFF
--- a/src/autocomplete/jquery.ui.autocomplete.accentFolding.js
+++ b/src/autocomplete/jquery.ui.autocomplete.accentFolding.js
@@ -8,6 +8,10 @@
  */
 (function( $ ) {
 
+if (typeof $.ui == "undefined" || typeof $.ui.autocomplete == "undefined"){
+	$.ui = { autocomplete: function () {} }
+}
+
 var autocomplete = $.ui.autocomplete;
 
 autocomplete.accentFolding = {


### PR DESCRIPTION
Create `$.ui.autocomplete` hierarchy if it doesn't exist instead of
simply failing.
This makes it possible to use the accent-folding code with typeahead.js and applications not using jQuery UI.
